### PR TITLE
Async

### DIFF
--- a/ColorArt/Classes/SLColorArt.h
+++ b/ColorArt/Classes/SLColorArt.h
@@ -22,6 +22,14 @@
 @property(strong, nonatomic, readonly) UIColor *primaryColor;
 @property(strong, nonatomic, readonly) UIColor *secondaryColor;
 @property(strong, nonatomic, readonly) UIColor *detailColor;
+@property(nonatomic, readonly) NSInteger randomColorThreshold; // Default to 2
 
 - (id)initWithImage:(UIImage*)image;
+- (id)initWithImage:(UIImage*)image threshold:(NSInteger)threshold;
+
++ (void)processImage:(UIImage *)image
+        scaledToSize:(CGSize)scaleSize
+           threshold:(NSInteger)threshold
+          onComplete:(void (^)(SLColorArt *colorArt))completeBlock;
+
 @end

--- a/ColorArt/Classes/SLColorArt.m
+++ b/ColorArt/Classes/SLColorArt.m
@@ -50,21 +50,49 @@
 @property(nonatomic,readwrite,strong) UIColor *primaryColor;
 @property(nonatomic,readwrite,strong) UIColor *secondaryColor;
 @property(nonatomic,readwrite,strong) UIColor *detailColor;
+@property(nonatomic,readwrite) NSInteger randomColorThreshold;
 @end
 
 @implementation SLColorArt
 
 - (id)initWithImage:(UIImage*)image
 {
+    self = [self initWithImage:image threshold:2];
+    if (self) {
+
+    }
+    return self;
+}
+
+- (id)initWithImage:(UIImage*)image threshold:(NSInteger)threshold;
+{
     self = [super init];
 
     if (self)
     {
+        self.randomColorThreshold = threshold;
         self.image = image;
         [self _processImage];
     }
 
     return self;
+}
+
+
++ (void)processImage:(UIImage *)image
+        scaledToSize:(CGSize)scaleSize
+           threshold:(NSInteger)threshold
+          onComplete:(void (^)(SLColorArt *colorArt))completeBlock;
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        UIImage *scaledImage = [image scaledToSize:scaleSize];
+        SLColorArt *colorArt = [[SLColorArt alloc] initWithImage:scaledImage
+                                                       threshold:threshold];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completeBlock(colorArt);
+        });
+    });
+    
 }
 
 - (void)_processImage
@@ -215,7 +243,7 @@ typedef struct RGBAPixel
 	{
 		NSUInteger colorCount = [edgeColors countForObject:curColor];
 
-		if ( colorCount <= 2 ) // prevent using random colors, threshold should be based on input image size
+		if ( colorCount <= self.randomColorThreshold ) // prevent using random colors, threshold should be based on input image size
 			continue;
 
 		PCCountedColor *container = [[PCCountedColor alloc] initWithColor:curColor count:colorCount];

--- a/ColorArt/Classes/SLColorArt.m
+++ b/ColorArt/Classes/SLColorArt.m
@@ -151,6 +151,14 @@
 	UIColor *primaryColor = nil;
 	UIColor *secondaryColor = nil;
 	UIColor *detailColor = nil;
+    
+    // If the random color threshold is too high and the image size too small,
+    // we could miss detecting the background color and crash.
+    if ( backgroundColor == nil )
+    {
+        backgroundColor = [UIColor whiteColor];
+    }
+    
 	BOOL darkBackground = [backgroundColor pc_isDarkColor];
 
 	[self _findTextColors:imageColors primaryColor:&primaryColor secondaryColor:&secondaryColor detailColor:&detailColor backgroundColor:backgroundColor];


### PR DESCRIPTION
Processing the image take a few seconds depending on the image size.

I've setup a async method for resizing the image and processing, makes it easier to use
it from the main thread.

I've also added a "random color threshold", which you had hardcoded to 2. There were a few album covers that, when resized, would not be able to detect a background color and would crash. I've also added a check for when the background color is nil.
