### PR TITLE
Improved Color Detection by a lot (simply setting pixelRange to 32

### DIFF
--- a/ColorArt/Classes/SLColorArt.m
+++ b/ColorArt/Classes/SLColorArt.m
@@ -212,7 +212,7 @@ typedef struct RGBAPixel
 {
 	CGImageRef imageRep = image.CGImage;
     
-    NSUInteger pixelRange = 8;
+    NSUInteger pixelRange = 32;
     NSUInteger scale = 256 / pixelRange;
     NSUInteger rawImageColors[pixelRange][pixelRange][pixelRange];
     NSUInteger rawEdgeColors[pixelRange][pixelRange][pixelRange];


### PR DESCRIPTION
Setting the pixelRange to 32 improves the background color detection by a lot.
Execution Time and CPU Usage is not much higher
